### PR TITLE
Index check

### DIFF
--- a/.changeset/famous-dryers-protect.md
+++ b/.changeset/famous-dryers-protect.md
@@ -1,0 +1,5 @@
+---
+"qlever": minor
+---
+
+Check if the data needs to be downloaded and if the index needs to be computed.

--- a/.changeset/new-games-draw.md
+++ b/.changeset/new-games-draw.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Upgrade base image to `adfreiburg/qlever:latest@sha256:90c4b7646489e3ea39a9f683b513b966ef435cbf9be6ccfc6b4c88e9446e476b`

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ docker compose --profile olympics down
 ## Relevant information about the QLever
 
 - [Some features are still missing](https://github.com/ad-freiburg/qlever/issues/615), but are being worked on.
+- [Current deviations from the SPARQL 1.1 standard](https://github.com/ad-freiburg/qlever/wiki/Current-deviations-from-the-SPARQL-1.1-standard)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ To stop the stack, you can use:
 docker compose --profile olympics down
 ```
 
+## Customize using specific environment variables
+
+Our custom container image for the server allows you to tweak the default behavior of the data download and the indexing using environment variables.
+
+- `SHOULD_INDEX`: If set to `true`, the server will index the data. If set to `false`, the server will not index the data. If the data needs to be downloaded, then the value will be swicth to `true` in all cases. Default is `false`.
+- `FORCE_INDEXING`: If set to `true`, the server will force the indexing of the data. Default is `false`.
+- `SHOULD_DOWNLOAD`: If set to `true`, the server will download the data. If the input file already exists, then the value would be set to `false` automatically. Default is `true`.
+- `FORCE_DOWNLOAD`: If set to `true`, the server will force the download of the data, even if `SHOULD_DOWNLOAD` is set to `false`. Default is `false`.
+
+If you want to persist the data, you can mount a volume to the `/home/qlever/data` directory.
+
 ## Relevant information about the QLever
 
 - [Some features are still missing](https://github.com/ad-freiburg/qlever/issues/615), but are being worked on.

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
+# Tweak indexing
+SHOULD_INDEX="${SHOULD_INDEX:-false}"
+FORCE_INDEXING="${FORCE_INDEXING:-false}"
+
+# Tweak data download
+SHOULD_DOWNLOAD="${SHOULD_DOWNLOAD:-true}"
+FORCE_DOWNLOAD="${FORCE_DOWNLOAD:-false}"
+
 set -eu
+
+# Display some debug information
+echo "INFO: Indexing : should index = ${SHOULD_INDEX} ; force indexing = ${FORCE_INDEXING}"
+echo "INFO: Data download : should download = ${SHOULD_DOWNLOAD} ; force download = ${FORCE_DOWNLOAD}"
 
 # Generate Qleverfile
 /home/qlever/scripts/generate-qleverfile.sh
@@ -20,13 +32,54 @@ fi
 echo "INFO: Qleverfile found at '${QLEVER_FILE_PATH}'"
 cat "${QLEVER_FILE_PATH}"
 
-# Check if there is a line that starts with `GET_DATA_CMD` in the Qleverfile
-if grep -q "^GET_DATA_CMD" "${QLEVER_FILE_PATH}"; then
-  echo "INFO: Found 'GET_DATA_CMD' in the Qleverfile, executing it"
-  qlever get-data
+INPUT_FILES=$(grep "^INPUT_FILES[[:space:]]*=" "${QLEVER_FILE_PATH}" | head -n1 | sed 's/.*=[[:space:]]*//')
+HAS_INPUT_FILES=$(echo "${INPUT_FILES}" | sed '/^[[:space:]]*$/d' | wc -l)
+
+if [ "${HAS_INPUT_FILES}" -ne 0 ]; then
+  echo "INFO: Found 'INPUT_FILES' in the Qleverfile"
+
+  # Check if the input files already exist
+  if [ -f "${INPUT_FILES}" ]; then
+    echo "INFO: Input files found at '${INPUT_FILES}'"
+    SHOULD_DOWNLOAD="false" # As the input files are already present, no need to download them
+  else
+    echo "INFO: Input files not found at '${INPUT_FILES}'"
+
+    # Display the info in the logs only if the download is enabled
+    if [ "${SHOULD_DOWNLOAD}" = "true" ]; then
+      echo "INFO: Trigger download of input files…"
+    fi
+  fi
 fi
 
-qlever index
+# If the download of the input files is forced, then download them in all cases
+if [ "${FORCE_DOWNLOAD}" = "true" ]; then
+  echo "INFO: Forcing download of input files…"
+  SHOULD_DOWNLOAD="true"
+fi
+
+# Check if there is a line that starts with `GET_DATA_CMD` in the Qleverfile
+if grep -q "^GET_DATA_CMD" "${QLEVER_FILE_PATH}"; then
+  echo "INFO: Found 'GET_DATA_CMD' in the Qleverfile"
+  if [ "${SHOULD_DOWNLOAD}" = "true" ]; then
+    echo "INFO: Trigger download of data…"
+    qlever get-data
+    SHOULD_INDEX="true" # As the data is downloaded, we should index it
+  else
+    echo "INFO: Skipping download of data…"
+  fi
+fi
+
+if [ "${SHOULD_INDEX}" = "true" ]; then
+  echo "INFO: Indexing is enabled"
+  qlever index
+elif [ "${FORCE_INDEXING}" = "true" ]; then
+  echo "INFO: Forcing indexing"
+  qlever index
+else
+  echo "INFO: Indexing is disabled"
+fi
+
 qlever start
 
 # Keep the container running


### PR DESCRIPTION
This allows to not always download and index the data if the data is already present.
This is useful for large datasets to start directly instead of waiting for the data download and the indexing process.