### PR TITLE
Add support for petrimaps

### DIFF
--- a/.changeset/calm-tables-end.md
+++ b/.changeset/calm-tables-end.md
@@ -2,4 +2,7 @@
 "qlever": minor
 ---
 
-Add support for petrimaps
+Add support for petrimaps.
+
+To configure the button that redirects to the map view, just define the `MAP_VIEW_BASE_URL` environment variable for the UI container.
+The default value is `""`, which will not display any button to open the map view.

--- a/.changeset/calm-tables-end.md
+++ b/.changeset/calm-tables-end.md
@@ -1,0 +1,5 @@
+---
+"qlever": minor
+---
+
+Add support for petrimaps

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Our custom container image for the server allows you to tweak the default behavi
 
 If you want to persist the data, you can mount a volume to the `/home/qlever/data` directory.
 
+The custom image for the UI also offers some environment variables to customize the behavior:
+
+- `MAP_VIEW_BASE_URL`: The base URL for the map view. Default is `""`, which will not display any button to open the map view.
+
 ## Relevant information about the QLever
 
 - [Some features are still missing](https://github.com/ad-freiburg/qlever/issues/615), but are being worked on.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,3 +66,13 @@ services:
       - server-local
     env_file:
       - local.env
+
+  qlever-petrimaps:
+    profiles:
+      - local
+      - olympics
+    image: registry.zazuko.tools/ludovicm67/registry/qlever-petrimaps:latest
+    stop_grace_period: 0s
+    restart: unless-stopped
+    ports:
+      - "7003:9090"

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -37,6 +37,8 @@ USER qlever
 
 WORKDIR /home/qlever
 
+COPY ./ui/update.py /app/backend/management/commands/update.py
+
 EXPOSE 7002
 
 ENTRYPOINT [ "" ]

--- a/docker/ui/entrypoint.sh
+++ b/docker/ui/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+MAP_VIEW_BASE_URL="${MAP_VIEW_BASE_URL:-}"
+
 set -eu
 
 # Generate Qleverfile
@@ -38,7 +40,14 @@ QLEVER_UI_WORKERS="${QLEVER_UI_WORKERS:-3}"
 QLEVER_UI_LIMIT_REQUEST_LINE="${QLEVER_UI_LIMIT_REQUEST_LINE:-10000}"
 
 # Configure the dataset
-python manage.py configure default "${QLEVER_SERVER_ENDPOINT}"
+BACKEND_SLUG="default"
+python manage.py configure "${BACKEND_SLUG}" "${QLEVER_SERVER_ENDPOINT}"
+
+# Configure the map URL if provided
+if [ -n "${MAP_VIEW_BASE_URL}" ]; then
+  echo "INFO: Setting the map view base URL to '${MAP_VIEW_BASE_URL}'"
+  python manage.py update "${BACKEND_SLUG}" "mapViewBaseURL" "${MAP_VIEW_BASE_URL}"
+fi
 
 # Start the UI
 gunicorn \

--- a/docker/ui/update.py
+++ b/docker/ui/update.py
@@ -1,0 +1,40 @@
+# Taken from https://github.com/ad-freiburg/qlever-ui/pull/111/commits/964e286868d23fd268669ac08098d7cf4dae5503
+
+from django.core.management.base import BaseCommand, CommandError
+from backend.models import Backend
+
+class Command(BaseCommand):
+    help = ("Usage: python manage.py update <backend_slug> <key> <value>\n"
+            "\n"
+            "Update key/value in database.")
+
+    # Copied from warmup.py, is this really needed?
+    def __init__(self, *args, **kwargs):
+        super().__init__( *args, **kwargs)
+
+    # Custom log function.
+    def log(self, msg=""):
+        print(msg)
+
+    # Command line arguments.
+    def add_arguments(self, parser):
+        parser.add_argument("backend_slug", nargs=1,
+                            help="Slug of the selected backend")
+        parser.add_argument("key", nargs=1,
+                            help="Key to update")
+        parser.add_argument("value", nargs=1,
+                            help="New value to set")
+
+    def handle(self, *args, returnLog=False, **options):
+        backend_slug = options["backend_slug"][0]
+        key = options["key"][0]
+        value = options["value"][0]
+
+        self.log(f"Update database: set {key} to {value} ...")
+        try:
+            backend = Backend.objects.filter(slug=backend_slug).get()
+            setattr(backend, key, value)
+            backend.save()
+        except Exception as e:
+            self.log(f"ERROR: {e}")
+            return

--- a/local.env
+++ b/local.env
@@ -13,3 +13,6 @@ QLEVER_SERVER_TIMEOUT=30s
 QLEVER_RUNTIME_SYSTEM=native
 QLEVER_UI_UI_CONFIG=data
 QLEVER_UI_UI_PORT=7002
+
+# Configure the base URL for the map view
+MAP_VIEW_BASE_URL=http://localhost:7003/

--- a/olympics.env
+++ b/olympics.env
@@ -16,3 +16,6 @@ QLEVER_SERVER_TIMEOUT=30s
 QLEVER_RUNTIME_SYSTEM=native
 QLEVER_UI_UI_CONFIG=olympics
 QLEVER_UI_UI_PORT=7002
+
+# Configure the base URL for the map view
+MAP_VIEW_BASE_URL=http://localhost:7003/


### PR DESCRIPTION
I just pushed a build for the Docker image for https://github.com/ad-freiburg/qlever-petrimaps at `registry.zazuko.tools/ludovicm67/registry/qlever-petrimaps:latest` for now (for linux/arm64 and linux/amd64 architectures), and I used it in the Docker Compose stack.

Right now the Docker image for petrimaps is not automatically built, but once it's the case, I will update the image used in the stack.
I created an issue to track this here: https://github.com/ad-freiburg/qlever-petrimaps/issues/20.

The UI custom image is also configured to configure the map URL using the value of the `MAP_VIEW_BASE_URL` environment variable.
This uses a script done by @NicoLaval in [his PR](https://github.com/ad-freiburg/qlever-ui/pull/111/commits/964e286868d23fd268669ac08098d7cf4dae5503) to update values from the database, so that the UI is able to redirect the user to the expected petrimaps instance.