### PR TITLE
Add some geo data

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -96,6 +96,34 @@ services:
   ######################
   # Petrimaps instance #
   ######################
+  petrimaps-redirect-local:
+    profiles:
+      - local
+    build:
+      context: ./redirect/
+      dockerfile: ./Dockerfile
+    stop_grace_period: 0s
+    environment:
+      - PUBLIC_MAPS_URL=http://localhost:7004
+      - PUBLIC_BACKEND_URL=http://localhost:7001
+      - PRIVATE_BACKEND_URL=http://server-local:7001
+    ports:
+      - "7003:7003"
+
+  petrimaps-redirect-olympics:
+    profiles:
+      - olympics
+    build:
+      context: ./redirect/
+      dockerfile: ./Dockerfile
+    stop_grace_period: 0s
+    environment:
+      - PUBLIC_MAPS_URL=http://localhost:7004
+      - PUBLIC_BACKEND_URL=http://localhost:7001
+      - PRIVATE_BACKEND_URL=http://server-olympics:7001
+    ports:
+      - "7003:7003"
+
   qlever-petrimaps:
     profiles:
       - local
@@ -104,4 +132,4 @@ services:
     stop_grace_period: 0s
     restart: unless-stopped
     ports:
-      - "7003:9090"
+      - "7004:9090"

--- a/docker/server/data.nt
+++ b/docker/server/data.nt
@@ -1,3 +1,4 @@
+# TBBT (The Big Bang Theory) dataset
 <http://localhost:8080/data/person/amy-farrah-fowler> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
 <http://localhost:8080/data/person/amy-farrah-fowler> <http://schema.org/additionalName> "Farrah" .
 <http://localhost:8080/data/person/amy-farrah-fowler> <http://schema.org/familyName> "Fowler" .
@@ -124,3 +125,39 @@ _:b4 <http://schema.org/streetAddress> "2311 North Los Robles Avenue, Apartment 
 <http://localhost:8080/data/person/stuart-bloom> <http://schema.org/knows> <http://localhost:8080/data/person/penny> .
 <http://localhost:8080/data/person/stuart-bloom> <http://schema.org/knows> <http://localhost:8080/data/person/rajesh-koothrappali> .
 <http://localhost:8080/data/person/stuart-bloom> <http://schema.org/knows> <http://localhost:8080/data/person/sheldon-cooper> .
+
+
+# France (polygon)
+
+## Feature
+<urn:test:geosparql:france:feature> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.opengis.net/ont/geosparql#Feature> .
+<urn:test:geosparql:france:feature> <http://www.w3.org/2000/01/rdf-schema#label> "France" .
+<urn:test:geosparql:france:feature> <http://www.opengis.net/ont/geosparql#hasGeometry> <urn:test:geosparql:france:geometry> .
+
+## Geometry
+<urn:test:geosparql:france:geometry> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.opengis.net/ont/geosparql#Geometry> .
+<urn:test:geosparql:france:geometry> <http://www.opengis.net/ont/geosparql#asWKT> "POLYGON((8.24127303627454 48.97794887560541,5.231019130024541 49.750647190315945,2.440491786274541 51.14961841626458,1.5176402237745412 50.87313049536895,1.5011607315870412 50.21336829946772,0.9133921768995412 49.99845644178497,0.21576034096204122 49.82512350296763,-0.2621449324754588 49.33718921868228,-1.8881214949754588 49.82157960827845,-2.085875401225459 49.394425976491604,-1.5365589949754588 48.73217609928656,-3.140562901225459 48.891343313415014,-4.942320713725459 48.630624713300485,-4.766539463725459 48.07577006394907,-4.371031651225459 47.75177459783237,-3.096617588725459 47.21722096602976,-1.5805043074754588 45.61162012205615,-1.7782582137254588 43.60971468750438,-1.8881214949754588 43.290685000073935,0.19928084877454122 42.61524836026427,0.8145152237745412 42.7928648459883,2.704163661274541 42.24222710444366,3.253480067524541 42.420905523667386,3.561097255024541 43.14657273329965,4.659730067524541 43.08241351640007,6.549378505024541 42.501955158864604,7.208558192524541 42.95389331205366,8.65875350502454 41.324731196577005,9.66949569252454 41.423662015262664,10.02105819252454 42.88953234551158,9.31793319252454 43.46635957827632,7.911683192524541 43.08241351640007,7.516175380024541 43.784463573801766,7.735901942524541 44.16396575789822,7.054749598774541 44.22698031120467,6.944886317524541 44.61929440132649,7.098694911274541 44.75988294318899,6.791077723774541 44.97789792588031,6.725159755024541 45.164110654364634,7.142640223774541 45.2724545718037,7.208558192524541 45.45770672352913,6.835023036274541 45.74978203327899,7.054749598774541 45.94874696966964,6.791077723774541 46.37487002615409,6.285706630024541 46.40518111104491,6.175843348774541 46.20785813977869,6.044007411274541 46.480885182821844,6.527405848774541 46.9178949511633,7.054749598774541 47.30669106481971,6.835023036274541 47.366253803971325,7.076722255024541 47.529704967777825,7.252503505024541 47.45547195118154,7.604066005024541 47.48517774971194,7.538148036274541 47.67785626638349,7.604066005024541 48.090448939567736,7.845765223774541 48.58704000495766,8.24127303627454 48.97794887560541))"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .
+
+
+# Strasbourg (point)
+
+## Feature
+<urn:test:geosparql:strasbourg:feature> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.opengis.net/ont/geosparql#Feature> .
+<urn:test:geosparql:strasbourg:feature> <http://www.w3.org/2000/01/rdf-schema#label> "Strasbourg" .
+<urn:test:geosparql:strasbourg:feature> <http://www.opengis.net/ont/geosparql#hasGeometry> <urn:test:geosparql:strasbourg:geometry> .
+
+## Geometry
+<urn:test:geosparql:strasbourg:geometry> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.opengis.net/ont/geosparql#Geometry> .
+<urn:test:geosparql:strasbourg:geometry> <http://www.opengis.net/ont/geosparql#asWKT> "POINT(7.7510315861075085 48.581903974563204)"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .
+
+
+# Bern (point)
+
+## Feature
+<urn:test:geosparql:bern:feature> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.opengis.net/ont/geosparql#Feature> .
+<urn:test:geosparql:bern:feature> <http://www.w3.org/2000/01/rdf-schema#label> "Bern" .
+<urn:test:geosparql:bern:feature> <http://www.opengis.net/ont/geosparql#hasGeometry> <urn:test:geosparql:bern:geometry> .
+
+## Geometry
+<urn:test:geosparql:bern:geometry> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.opengis.net/ont/geosparql#Geometry> .
+<urn:test:geosparql:bern:geometry> <http://www.opengis.net/ont/geosparql#asWKT> "POINT(7.448102905878211 46.945410623891554)"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .

--- a/redirect/Dockerfile
+++ b/redirect/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/denoland/deno:2.1.4
+
+EXPOSE 7003
+WORKDIR /app
+
+USER deno
+
+COPY main.ts ./
+RUN deno cache main.ts
+
+CMD [ "run", "--allow-net", "--allow-env", "main.ts" ]

--- a/redirect/README.md
+++ b/redirect/README.md
@@ -1,0 +1,19 @@
+# Redirect app
+
+This Deno application is responsible for redirecting the user to the correct URL by updating the query parameters.
+It is used in the Docker Compose stack to rewrite the `backend` URL to the internal URL of the QLever server so that Petrimaps can access the QLever server.
+
+## Usage
+
+To start the redirect app, you can use the following command:
+
+```sh
+docker build -t redirect .
+docker run --rm -p 7003:7003 -it redirect
+```
+
+## Environment variables
+
+- `PUBLIC_MAPS_URL`: The public URL of the maps service. Default is `http://localhost:7004`.
+- `PUBLIC_BACKEND_URL`: The public URL of the backend service. Default is `http://localhost:7001`.
+- `PRIVATE_BACKEND_URL`: The private URL of the backend service. Default is `http://server-local:7001`.

--- a/redirect/main.ts
+++ b/redirect/main.ts
@@ -1,0 +1,35 @@
+const PUBLIC_MAPS_URL =
+  Deno.env.get("PUBLIC_MAPS_URL") || "http://localhost:7004";
+const PUBLIC_BACKEND_URL =
+  Deno.env.get("PUBLIC_BACKEND_URL") || "http://localhost:7001";
+const PRIVATE_BACKEND_URL =
+  Deno.env.get("PRIVATE_BACKEND_URL") || "http://server-local:7001";
+
+const handler = async (req: Request): Promise<Response> => {
+  const url = new URL(req.url);
+
+  // Construct the redirect URL to PUBLIC_MAPS_URL
+  let targetUrl = new URL(PUBLIC_MAPS_URL);
+  targetUrl.pathname = url.pathname;
+  targetUrl.search = url.search;
+
+  // Rewrite backend query parameter if it exists
+  if (url.searchParams.has("backend")) {
+    const backendUrl = url.searchParams.get("backend");
+    console.log("backendUrl", backendUrl);
+    if (backendUrl && backendUrl.includes(PUBLIC_BACKEND_URL)) {
+      console.log("rewriting backend URL");
+      const rewrittenUrl = backendUrl.replace(
+        PUBLIC_BACKEND_URL,
+        PRIVATE_BACKEND_URL
+      );
+      targetUrl.searchParams.set("backend", rewrittenUrl);
+      console.log("rewritten backend URL", rewrittenUrl);
+    }
+  }
+
+  // Redirect the client to the new URL
+  return Response.redirect(targetUrl.toString(), 302);
+};
+
+Deno.serve({ hostname: "0.0.0.0", port: "7003" }, handler);


### PR DESCRIPTION
This updates the local stack with some additional data, in order to be able to try Petrimaps.

Example of SPARQL query that could be used to see the "Map view" button:

```sparql
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX geo: <http://www.opengis.net/ont/geosparql#>

SELECT * WHERE {
  ?feature geo:hasGeometry ?hasGeometry .
  ?feature rdfs:label ?label .
  ?hasGeometry geo:asWKT ?geometry .
}
```

This should lead to this result:

![image](https://github.com/user-attachments/assets/d4dc5a82-b2e2-4ab1-93a2-e38959572ff6)
