### PR TITLE
Add support for `auto` value for `QLEVER_GENERATE_CONFIG_FILE`

### DIFF
--- a/.changeset/itchy-peaches-smile.md
+++ b/.changeset/itchy-peaches-smile.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Add support for `auto` value for `QLEVER_GENERATE_CONFIG_FILE`

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ docker compose --profile olympics down
 
 ## Customize using specific environment variables
 
+### Common
+
+- `QLEVER_GENERATE_CONFIG_FILE`: If set to `true`, the server will generate a configuration file for QLever (Qleverfile) based on the environment variables. If set to `auto`, it will only generate it if the file is missing. Default is `true`.
+
 ### Server
 
 Our custom container image for the server allows you to tweak the default behavior of the data download and the indexing using environment variables.

--- a/docker/common/generate-qleverfile.sh
+++ b/docker/common/generate-qleverfile.sh
@@ -6,14 +6,26 @@ set -eu
 # This script generates a Qleverfile that can be used to start a QLever instance #
 ##################################################################################
 
+QLEVER_FILE_PATH="${QLEVER_FILE_PATH:-/data/Qleverfile}"
+
 # Have a way to opt-out of generating the Qleverfile
 QLEVER_GENERATE_CONFIG_FILE="${QLEVER_GENERATE_CONFIG_FILE:-true}"
+if [ "${QLEVER_GENERATE_CONFIG_FILE}" = "auto" ]; then
+  # Check if the Qleverfile already exists
+  if [ -f "${QLEVER_FILE_PATH}" ]; then
+    echo "INFO: Skipping Qleverfile generation, as 'QLEVER_GENERATE_CONFIG_FILE' is set to 'auto' and the file already exists at '${QLEVER_FILE_PATH}'"
+    exit 0
+  else
+    echo "INFO: Generating Qleverfile, as 'QLEVER_GENERATE_CONFIG_FILE' is set to 'auto' and the file does not exist at '${QLEVER_FILE_PATH}'"
+    QLEVER_GENERATE_CONFIG_FILE="true"
+  fi
+fi
+
 if [ "${QLEVER_GENERATE_CONFIG_FILE}" != "true" ]; then
   echo "INFO: Skipping Qleverfile generation, as 'QLEVER_GENERATE_CONFIG_FILE' is not set to 'true'"
   exit 0
 fi
 
-QLEVER_FILE_PATH="${QLEVER_FILE_PATH:-/data/Qleverfile}"
 dirname "${QLEVER_FILE_PATH}" | xargs mkdir -p
 
 # Set default values for some configuration fields (could be overridden by other environment variables)

--- a/local.env
+++ b/local.env
@@ -1,5 +1,6 @@
 QLEVER_DATA_NAME=local
 QLEVER_DATA_DESCRIPTION=Data coming from a local file
+QLEVER_DATA_FORMAT=nt
 QLEVER_INDEX_INPUT_FILES=data.nt
 QLEVER_INDEX_CAT_INPUT_FILES=cat ${QLEVER_INDEX_INPUT_FILES}
 QLEVER_INDEX_SETTINGS_JSON={ "ascii-prefixes-only": false, "num-triples-per-batch": 100000 }


### PR DESCRIPTION
Closes #43.

By default, `QLEVER_GENERATE_CONFIG_FILE` is set to `true`, which will trigger the generation of the Qleverfile by default based on the environment variables every time.

By setting it to `auto`, it will only generate it if the Qleverfile file is missing.

Setting it to `false` (or any other value) will ignore the build of that file.