### PR TITLE
Bump `qlever-control` to 5.18

### DIFF
--- a/.changeset/angry-horses-carry.md
+++ b/.changeset/angry-horses-carry.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Bump qlever-control to 5.18

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,5 +1,5 @@
 # Check latest version here: https://pypi.org/project/qlever/
-ARG QLEVER_VERSION="0.5.17"
+ARG QLEVER_VERSION="0.5.18"
 
 FROM index.docker.io/adfreiburg/qlever-ui:latest@sha256:5ab6e9a2f44d159737c9fe0c7cd7f1bd6f10b43cefd0b8130a6c1fbc979252fa
 


### PR DESCRIPTION
This upgrades `qlever-control` to 5.18 in the UI image.