### PR TITLE
CI: Make sure that init is always triggered first

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Build Docker images (local)
         run: docker compose --profile local build
 
+      - name: Just make sure that permissions are fixed (local)
+        run: docker compose --profile local up init-local -d
+
       # Test:
       # - if the stack is able to be started
       # - if a user is able to perform a basic SPARQL query

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ docker compose --profile local up # Start the stack
 
 And then you can access the UI at `http://localhost:7002`.
 
+In case you see a permission error in the logs, you can run the following command to fix it:
+
+```sh
+docker compose --profile local up init-local -d
+```
+
 To stop the stack, you can use:
 
 ```sh
@@ -35,6 +41,12 @@ docker compose --profile olympics up # Start the stack
 ```
 
 And then you can access the UI at `http://localhost:7002`.
+
+In case you see a permission error in the logs, you can run the following command to fix it:
+
+```sh
+docker compose --profile olympics up init-olympics -d
+```
 
 To stop the stack, you can use:
 


### PR DESCRIPTION
Some jobs were failing because of permissions issues.
Those permissions are solved by using the `init` service created for each stack.
This ensures that the init service is called first before the rest of the stack.