### PR TITLE
Small improvements in server Docker image

### DIFF
--- a/.changeset/khaki-breads-invent.md
+++ b/.changeset/khaki-breads-invent.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Update `PATH` directly in the Dockerfile, so that it includes `/qlever`

--- a/.changeset/salty-lines-divide.md
+++ b/.changeset/salty-lines-divide.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Upgrade `server` base image to `7872df7`

--- a/.changeset/some-pumas-sing.md
+++ b/.changeset/some-pumas-sing.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Change order of steps in the Dockerfile

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -56,6 +56,7 @@ COPY --from=soc /app/stop_on_call /usr/bin/stop_on_call
 
 # Install QLever
 COPY --from=qlever /qlever/IndexBuilderMain /qlever/ServerMain /qlever/
+ENV PATH="/qlever:${PATH}"
 RUN pipx install --global "qlever==${QLEVER_VERSION}"
 
 # Use the nobody user by default

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -3,7 +3,7 @@ ARG QLEVER_VERSION="0.5.23"
 
 # Dependency images
 FROM ghcr.io/ludovicm67/stop-on-call:v0.1.0 AS soc
-FROM index.docker.io/adfreiburg/qlever:latest@sha256:40d73f4929ff30926cc8d142e08b9bb88d8cfcea75be1a509e835af0444752b9 AS qlever
+FROM index.docker.io/adfreiburg/qlever:latest@sha256:7872df70da435e1a79e59a734fd97964ad22f0deefe5ac92bcfb67f1aa1c7997 AS qlever
 
 # Final image
 FROM ubuntu:24.10

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -44,6 +44,11 @@ RUN echo 'PATH="/qlever:${PATH}"' >> /etc/bash.bashrc
 ENV QLEVER_ARGCOMPLETE_ENABLED="1"
 ENV QLEVER_IS_RUNNING_IN_CONTAINER="1"
 
+# Install QLever
+COPY --from=qlever /qlever/IndexBuilderMain /qlever/ServerMain /qlever/
+ENV PATH="/qlever:${PATH}"
+RUN pipx install --global "qlever==${QLEVER_VERSION}"
+
 # Include some useful scripts
 RUN mkdir -p /qlever/scripts
 COPY ./common/generate-qleverfile.sh /qlever/scripts/
@@ -53,11 +58,6 @@ RUN chmod +x /qlever/scripts/*.sh
 # Configure Stop On Call
 ENV STOP_ON_CALL_ENABLED="false"
 COPY --from=soc /app/stop_on_call /usr/bin/stop_on_call
-
-# Install QLever
-COPY --from=qlever /qlever/IndexBuilderMain /qlever/ServerMain /qlever/
-ENV PATH="/qlever:${PATH}"
-RUN pipx install --global "qlever==${QLEVER_VERSION}"
 
 # Use the nobody user by default
 USER 65534

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -22,9 +22,6 @@ set -euo pipefail
 echo "INFO: Indexing : should index = ${SHOULD_INDEX} ; force indexing = ${FORCE_INDEXING}"
 echo "INFO: Data download : should download = ${SHOULD_DOWNLOAD} ; force download = ${FORCE_DOWNLOAD}"
 
-# Update the PATH to include the QLever binary
-export PATH="/qlever:${PATH}"
-
 # Generate Qleverfile
 /qlever/scripts/generate-qleverfile.sh
 


### PR DESCRIPTION
This PR does the following:
- directly update the `PATH` in the Dockerfile, so that we have something that works well in most of the situations
- change the step order, so that we can see our extra layers
- upgrade base image to `7872df7`