### PR TITLE
[2026-05-21] Various upgrades in server image

### DIFF
--- a/.changeset/five-parrots-rhyme.md
+++ b/.changeset/five-parrots-rhyme.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Bump pipx to 1.12.0

--- a/.changeset/neat-drinks-look.md
+++ b/.changeset/neat-drinks-look.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Bump server base image to `sha256:405b26993a03c636c55cf8e1b54be49463aa0f5968176e5528abd7a25c2e346e`

--- a/.changeset/spotty-ducks-prove.md
+++ b/.changeset/spotty-ducks-prove.md
@@ -1,0 +1,5 @@
+---
+"qlever": patch
+---
+
+Upgrade `sophia-cli` to `2b7221ca0e6776c3a382f90f9c66cc0d0b37cb71`

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -4,7 +4,7 @@ ARG QLEVER_VERSION="0.5.47"
 # Check latest pipx version here: https://github.com/pypa/pipx/releases
 ARG PIPX_VERSION="1.11.1"
 
-ARG SOPHIA_CLI_VERSION="95a6d1fa170973cfdaaf3743099ba91153fb58f8"
+ARG SOPHIA_CLI_VERSION="2b7221ca0e6776c3a382f90f9c66cc0d0b37cb71"
 
 FROM rust:bookworm AS sophia-cli-builder
 

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -22,7 +22,7 @@ RUN cargo build --release
 
 # Dependency images
 FROM ghcr.io/ludovicm67/stop-on-call:v0.1.0 AS soc
-FROM index.docker.io/adfreiburg/qlever:latest@sha256:6c8d7a552fdffb885a6fb0d07742dc375e982670563651d46a8c0887191b4cab AS qlever
+FROM index.docker.io/adfreiburg/qlever:latest@sha256:405b26993a03c636c55cf8e1b54be49463aa0f5968176e5528abd7a25c2e346e AS qlever
 
 # Final image
 FROM ubuntu:24.04

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -2,7 +2,7 @@
 ARG QLEVER_VERSION="0.5.47"
 
 # Check latest pipx version here: https://github.com/pypa/pipx/releases
-ARG PIPX_VERSION="1.11.1"
+ARG PIPX_VERSION="1.12.0"
 
 ARG SOPHIA_CLI_VERSION="2b7221ca0e6776c3a382f90f9c66cc0d0b37cb71"
 


### PR DESCRIPTION
This upgrades the following in the server image:
- pipx: 1.12.0
- sophia-cli: `2b7221ca0e6776c3a382f90f9c66cc0d0b37cb71`
- server base image: `sha256:405b26993a03c636c55cf8e1b54be49463aa0f5968176e5528abd7a25c2e346e`